### PR TITLE
Update mbuild cmake commands

### DIFF
--- a/mbuild
+++ b/mbuild
@@ -4,7 +4,7 @@
 help() {
     echo -e "Usage: mbuild [-c | --config-only] [-m | --make-only]
               [-s | --skip-tests] [-dd | --dest-dir]
-              [-h | --help]"
+              [-h | --help] [-v | --verbose]"
     exit 0
 }
 
@@ -12,6 +12,7 @@ config_only=false
 make_only=false
 skip_tests=false
 dest_dir=$CONDA_PREFIX
+verbose=
 
 i=1;
 for argument in "$@"; do
@@ -27,6 +28,9 @@ for argument in "$@"; do
             ;;
         -s|--skip-tests)
             skip_tests=true
+            ;;
+        -v|--verbose)
+            verbose=-V
             ;;
         -dd|--dest-dir)
             dest_dir=$PWD/_install
@@ -53,7 +57,7 @@ if [ $? != 0 ]; then exit 1; fi
 if $make_only; then exit 0; fi
 
 if [ $skip_tests = false ]; then
-    ctest --test-dir $build_dir
+    ctest $verbose --test-dir $build_dir
 fi
 
 if [ $? != 0 ]; then

--- a/mbuild
+++ b/mbuild
@@ -11,7 +11,7 @@ help() {
 config_only=false
 make_only=false
 skip_tests=false
-dest_dir=
+dest_dir=$CONDA_PREFIX
 
 i=1;
 for argument in "$@"; do
@@ -45,28 +45,21 @@ done
 build_type=Release
 build_dir=_build
 
-if [ -e $dest_dir ]; then rm -rf $dest_dir; fi
-
-if [ -e $build_dir ]; then rm -r $build_dir; fi
-mkdir $build_dir && cd $build_dir
-
-cmake .. \
-    -DCMAKE_BUILD_TYPE=$build_type \
-    -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
+cmake -B $build_dir --fresh -DCMAKE_BUILD_TYPE=$build_type
 if $config_only; then exit 0; fi
 
-make -s
+cmake --build $build_dir
 if [ $? != 0 ]; then exit 1; fi
 if $make_only; then exit 0; fi
 
 if [ $skip_tests = false ]; then
-    ctest --test-dir .
+    ctest --test-dir $build_dir
 fi
 
 if [ $? != 0 ]; then
     exit 1
 else
-    make DESTDIR=$dest_dir install
+    cmake --install $build_dir --prefix $dest_dir
 fi
 
 exit 0

--- a/mbuild
+++ b/mbuild
@@ -2,9 +2,20 @@
 # Script my typical cmake build process.
 
 help() {
-    echo -e "Usage: mbuild [-c | --config-only] [-m | --make-only]
-              [-s | --skip-tests] [-dd | --dest-dir]
-              [-h | --help] [-v | --verbose]"
+    echo -e \
+"Usage
+
+    mbuild [options]
+
+Options
+
+    -c, --config-only   Configure project; don't make or install
+    -m, --make-only     Configure and make project; don't install
+    -s, --skip-tests    Don't run ctest
+    -dd, --dest-dir     Use a local install directory (_install)
+    -h, --help          Show this help message
+    -v, --verbose       Enable verbose output
+"
     exit 0
 }
 


### PR DESCRIPTION
I updated the `mbuild` command to make use of the CMake `-B`, `--build`, and `--install` options, as well as fixing a bug in handling the `skip_test` flag. I also reformatted the command's help output.